### PR TITLE
Switch from using object filters to using ASTs

### DIFF
--- a/examples/example.js
+++ b/examples/example.js
@@ -1,15 +1,56 @@
+var util = require('util');
+var Readable = require('stream').Readable;
+
 var through = require('through');
-var JSONStream = require('JSONStream');
 var fs = require('fs');
 var LogicFilter = require('../index');
+var redis = require('redis');
+
+var rc = redis.createClient();
 
 var lf = new LogicFilter();
 
-lf.add('testRule', {not: {'metadata': 'foo'}});
+lf.add('testRule', {
+  and: {
+    'checkType': 'remote.http'
+    /*'monitoringZoneId': 'mzdfw',
+    'metrics': {
+      'duration': {
+        'valueI32': 70
+      }
+    }*/
+  }
+});
 
-fs.createReadStream('./examples/exampleObjects.json')
-  .pipe(JSONStream.parse())
-  .pipe(lf)
+var RedisRead = function() {
+  Readable.call(this, {objectMode: true});
+  var self = this;
+
+  this.rc = redis.createClient();
+
+  rc.on('pmessage', function(pattern, channel, msg) {
+    total++;
+    self.push(JSON.parse(msg));
+  });
+};
+util.inherits(RedisRead, Readable);
+
+RedisRead.prototype._read = function() {
+  rc.psubscribe('*.remote.http.*');
+};
+
+var rr = new RedisRead();
+
+var count = 0;
+var total = 0;
+var start = Date.now();
+rr.pipe(lf)
   .pipe(through(function(obj) {
-    console.log('obj: ' + JSON.stringify(obj, null, 4));
+    //console.log(JSON.stringify(obj, null, 4));
+    count++;
   }));
+
+setInterval(function() {
+  var duration = (Date.now() - start) / 1000;
+  console.log(total / duration, count / duration);
+}, 10000);

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "url": "https://github.com/jirwin/node-logic-filter/issues"
   },
   "dependencies": {
-    "logic-filter-strings": "0.0.0",
+    "logic-filter-strings": "0.0.1",
     "underscore": "~1.7.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "url": "https://github.com/jirwin/node-logic-filter/issues"
   },
   "dependencies": {
+    "logic-filter-strings": "0.0.0",
     "underscore": "~1.7.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "url": "https://github.com/jirwin/node-logic-filter/issues"
   },
   "dependencies": {
-    "logic-filter-strings": "0.0.1",
+    "logic-filter-strings": "0.0.2",
     "underscore": "~1.7.0"
   },
   "devDependencies": {

--- a/test/index.js
+++ b/test/index.js
@@ -632,6 +632,65 @@ test('rule: literal array equality', function(t) {
 });
 
 
+test('rule: simple array in array', function(t) {
+  var lf = new LogicFilter(),
+      fixture = tst(t, lf);
+
+  lf.add('simpleRule', {
+    'foo': [[1, 2, 3]]
+  });
+
+  t.plan(1);
+
+  fixture.deepEqual([
+      {'foo': [1, 2, 3]},
+      {'foo': 1},
+      {'foo': 2},
+      {'foo': 3},
+      {'foo': 4},
+      {'bar': [1, 2, 3]},
+      {},
+      0,
+      undefined
+    ], [
+      {'foo': [1, 2, 3], 'label': 'simpleRule'}
+    ],
+    'Rule matched and labeled 1 object',
+    t.ok);
+});
+
+
+test('rule: array/values in array', function(t) {
+  var lf = new LogicFilter(),
+      fixture = tst(t, lf);
+
+  lf.add('simpleRule', {
+    'foo': [[1, 2, 3], 1, 2, 3]
+  });
+
+  t.plan(1);
+
+  fixture.deepEqual([
+      {'foo': [1, 2, 3]},
+      {'foo': 1},
+      {'foo': 2},
+      {'foo': 3},
+      {'foo': 4},
+      {'bar': [1, 2, 3]},
+      {},
+      0,
+      undefined
+    ], [
+      {'foo': [1, 2, 3], 'label': 'simpleRule'},
+      {'foo': 1, 'label': 'simpleRule'},
+      {'foo': 2, 'label': 'simpleRule'},
+      {'foo': 3, 'label': 'simpleRule'}
+    ],
+    'Rule matched and labeled 4 object',
+    t.ok);
+});
+
+
 test('rule: literal object equality', function(t) {
   var lf = new LogicFilter(),
       fixture = tst(t, lf);
@@ -843,14 +902,10 @@ test('null filter', function(t) {
 });
 
 
-test('rule: literal object equality', function(t) {
+test('rule: invalid filter throws', function(t) {
   var lf = new LogicFilter();
 
-  lf.add('simpleRule', {
-    and: 'foo'
-  });
-
-  t.throws(lf.write.bind(lf, {'foo': {'bar': 'baz'}}));
+  t.throws(lf._applyFilter.bind(lf, 'and', {and: 'foo'}, {'foo': {'bar': 'baz'}}));
   t.end();
 });
 
@@ -1421,4 +1476,303 @@ test('rule: multiple complex', function(t) {
     ],
     'Rule matched and labeled 7 objects',
     t.ok);
+});
+
+
+test('rule: validation', function(t) {
+  var lf = LogicFilter(),
+      goodRules = {
+        simple: {
+          'foo': 'bar'
+        },
+        simpleAnd: {
+          and: {
+            'foo': 'bar',
+            'bar': 'baz'
+          }
+        },
+        simpleImpliedAnd: {
+          'foo': 'bar',
+          'bar': 'baz'
+        },
+        simpleOr: {
+          or: {
+            'foo': 'bar',
+            'bar': 'baz'
+          }
+        },
+        simpleNot: {
+          not: {
+            'foo': 'bar'
+          }
+        },
+        simpleAny: {
+          'foo': [1, 2, 3]
+        },
+        notImpliedAnd: {
+          not: {
+            'foo': 'bar',
+            'bar': 'baz'
+          }
+        },
+        notAnd: {
+          not: {
+            and: {
+              'foo': 'bar',
+              'bar': 'baz'
+            }
+          }
+        },
+        notOr: {
+          not: {
+            or: {
+              'foo': 'bar',
+              'bar': 'baz'
+            }
+          }
+        },
+        simpleValue: {
+          'foo': {
+            value: [1, 2, 3]
+          }
+        },
+        simpleValue2: {
+          'foo': {
+            value: {
+              'foo': 'bar'
+            }
+          }
+        },
+        simpleValue3: {
+          'foo': {
+            value: 'bar'
+          }
+        },
+        simpleExistsTrue: {
+          'foo': {
+            exists: true
+          }
+        },
+        simpleExistsFalse: {
+          'foo': {
+            exists: false
+          }
+        },
+        nestedAndOr: {
+          and: {
+            or: {
+              'foo': 'bar',
+              'bar': 'baz'
+            },
+            'qux': 'foo'
+          }
+        },
+        nestedOrAnd: {
+          or: {
+            and: {
+              'foo': 'bar',
+              'bar': 'baz'
+            },
+            'qux': 'foo'
+          }
+        },
+        nestedNotAnd: {
+          not: {
+            and: {
+              'foo': 'bar',
+              'bar': 'baz'
+            },
+            'qux': 'foo'
+          }
+        },
+        nestedAndNot: {
+          and: {
+            not: {
+              'foo': 'bar',
+              'bar': 'baz'
+            },
+            'qux': 'foo'
+          }
+        },
+        nestedNotOr: {
+          not: {
+            or: {
+              'foo': 'bar',
+              'bar': 'baz'
+            },
+            'qux': 'foo'
+          }
+        },
+        nestedOrNot: {
+          or: {
+            not: {
+              'foo': 'bar',
+              'bar': 'baz'
+            },
+            'qux': 'foo'
+          }
+        },
+        nestedAndExists: {
+          and: {
+            'foo': {
+              exists: true
+            },
+            'qux': 'foo'
+          }
+        },
+        nestedOrExists: {
+          or: {
+            'foo': {
+              exists: true
+            },
+            'qux': 'foo'
+          }
+        },
+        nestedNotExists: {
+          not: {
+            'foo': {
+              exists: true
+            },
+            'qux': 'foo'
+          }
+        },
+        nestedAndValue: {
+          and: {
+            'foo': {
+              value: {
+                'bar': 'baz'
+              }
+            },
+            'qux': 'foo'
+          }
+        },
+        nestedOrValue: {
+          or: {
+            'foo': {
+              value: {
+                'bar': 'baz'
+              }
+            },
+            'qux': 'foo'
+          }
+        },
+        nestedNotValue: {
+          not: {
+            'foo': {
+              value: {
+                'bar': 'baz'
+              }
+            },
+            'qux': 'foo'
+          }
+        },
+        nestedAndAny: {
+          and: {
+            'foo': [1, 2, 3],
+            'qux': 'foo'
+          }
+        },
+        nestedOrAny: {
+          or: {
+            'foo': [1, 2, 3],
+            'qux': 'foo'
+          }
+        },
+        nestedNotAny: {
+          not: {
+            'foo': [1, 2, 3],
+            'qux': 'foo'
+          }
+        }
+      },
+      badRules = {
+        emptyRule: {},
+        nullRule: null,
+        undefinedRule: undefined,
+        badExists: {
+          'foo': {
+            exists: null
+          }
+        },
+        badExists2: {
+          'foo': {
+            exists: undefined
+          }
+        },
+        badExists3: {
+          'foo': {
+            exists: 0
+          }
+        },
+        badExists4: {
+          'foo': {
+            exists: 1
+          }
+        },
+        badExists5: {
+          'foo': {
+            exists: 'bar'
+          }
+        },
+        badAnd: {
+          and: 'foo'
+        },
+        badOr: {
+          or: 'foo'
+        },
+        badNot: {
+          not: 'foo'
+        },
+        badAndNot: {
+          and: {
+            not: 'foo'
+          }
+        },
+        badAndOr: {
+          and: {
+            or: 'foo'
+          }
+        },
+        badOrAnd: {
+          or: {
+            and: 'foo'
+          }
+        },
+        badOrNot: {
+          or: {
+            not: 'foo'
+          }
+        },
+        badNotAnd: {
+          not: {
+            and: 'foo'
+          }
+        },
+        badNotOr: {
+          not: {
+            or: 'foo'
+          }
+        }
+      };
+
+
+  Object.keys(goodRules).forEach(function(rule) {
+    t.ok(LogicFilter.validate(goodRules[rule]), 'Rule: ' + rule + ' should pass validation');
+  });
+
+  Object.keys(badRules).forEach(function(rule) {
+    t.ifError(LogicFilter.validate(badRules[rule]), 'Rule: ' + rule + ' should fail validation');
+  });
+
+  t.end();
+});
+
+test('rule: add/update invalid rules', function(t) {
+  var lf = new LogicFilter();
+
+  t.ifError(lf.add('invalidRule', {}), 'Empty rule should not be added');
+  lf.add('simpleRule', {'foo': 'bar'});
+  t.ifError(lf.update('simpleRule', {}), 'Rule cannot be updated to empty rule');
+  t.ifError(lf.update('newRule', {'foo': 'bar'}), 'Nonexistent rule cannot be updated');
+  t.end();
 });

--- a/test/index.js
+++ b/test/index.js
@@ -1064,8 +1064,7 @@ test('setDelimiter', function(t) {
     100);
 });
 
-//FAIL (fix in next release of logic-filter-string)
-/*test('rule: doubly nested object string', function(t) {
+test('rule: doubly nested object string', function(t) {
   var lf = new LogicFilter(),
       fixture = tst(t, lf);
 
@@ -1091,4 +1090,4 @@ test('setDelimiter', function(t) {
     ],
     'Rule matched and labeled 3 objects',
     t.ok);
-});*/
+});

--- a/test/index.js
+++ b/test/index.js
@@ -834,7 +834,7 @@ test('rule: exists string', function(t) {
 });
 
 
-test('rule: exists false string', function(t) {
+test('rule: not exists string', function(t) {
   var lf = new LogicFilter(),
       fixture = tst(t, lf);
 
@@ -859,6 +859,66 @@ test('rule: exists false string', function(t) {
       {'label': 'simpleRule'}
     ],
     'Rule matched and labeled 2 objects',
+    t.ok);
+});
+
+test('rule: exists nested string', function(t) {
+  var lf = new LogicFilter(),
+      fixture = tst(t, lf);
+
+  lf.add('simpleRule', '!foo.bar');
+
+  t.plan(1);
+
+  fixture.deepEqual([
+      {'foo': {'bar': 1}},
+      {'foo': {'bar': true}},
+      {'foo': {'bar': false}},
+      {'foo': {'bar': null}},
+      {'foo': {'bar': 'one'}},
+      {'foo': {'bar': {'bar': 'baz'}}},
+      {'foo': {'bar': [1, 2, 3]}},
+      {'bar': 'foo'},
+      {},
+      0,
+      undefined
+    ], [
+      {'bar': 'foo', 'label': 'simpleRule'}
+    ],
+    'Rule matched and labeled 1 object',
+    t.ok);
+});
+
+test('rule: not exists nested string', function(t) {
+  var lf = new LogicFilter(),
+      fixture = tst(t, lf);
+
+  lf.add('simpleRule', 'foo.bar');
+
+  t.plan(1);
+
+  fixture.deepEqual([
+      {'foo': {'bar': 1}},
+      {'foo': {'bar': true}},
+      {'foo': {'bar': false}},
+      {'foo': {'bar': null}},
+      {'foo': {'bar': 'one'}},
+      {'foo': {'bar': {'bar': 'baz'}}},
+      {'foo': {'bar': [1, 2, 3]}},
+      {'bar': 'foo'},
+      {},
+      0,
+      undefined
+    ], [
+      {'foo': {'bar': 1}, 'label': 'simpleRule'},
+      {'foo': {'bar': true}, 'label': 'simpleRule'},
+      {'foo': {'bar': false}, 'label': 'simpleRule'},
+      {'foo': {'bar': null}, 'label': 'simpleRule'},
+      {'foo': {'bar': 'one'}, 'label': 'simpleRule'},
+      {'foo': {'bar': {'bar': 'baz'}}, 'label': 'simpleRule'},
+      {'foo': {'bar': [1, 2, 3]}, 'label': 'simpleRule'}
+    ],
+    'Rule matched and labeled 7 objects',
     t.ok);
 });
 
@@ -922,7 +982,84 @@ test('rule: simple remove', function(t) {
       0,
       undefined
     ], [],
-    'Rule matched and labeled 1 object',
+    'Rule matched and labeled 0 objects',
+    t.ok,
+    100);
+});
+
+
+test('setDelimiter option', function(t) {
+  var lf = new LogicFilter({'delimiter': '_'}),
+      fixture = tst(t, lf);
+
+  lf.add('simpleRule', 'foo.bar == "baz"');
+  lf.add('simpleRule2', 'foo_bar == "baz"');
+
+  t.plan(1);
+
+  fixture.deepEqual([
+      {'foo': {'bar': "baz"}},
+      {'foo.bar': 'baz'},
+      {'foo_bar': 'baz'},
+      {'foo': {'bar': "qux"}},
+      {'foo.bar': 'qux'},
+      {'foo:bar': 'qux'},
+      {},
+      0,
+      undefined
+    ], [
+      {'foo': {'bar': "baz"}, 'label': 'simpleRule2'},
+      {'foo.bar': 'baz', 'label': 'simpleRule'}
+    ],
+    'Rule matched and labeled 2 objects',
+    t.ok);
+});
+
+
+test('setDelimiter', function(t) {
+  var lf = new LogicFilter(),
+      fixture = tst(t, lf);
+
+  lf.add('simpleRule', 'foo.bar == "baz"');
+  lf.add('simpleRule2', 'foo_bar == "baz"');
+
+  t.plan(2);
+
+  console.log()
+  fixture.deepEqual([
+      {'foo': {'bar': "baz"}},
+      {'foo.bar': 'baz'},
+      {'foo_bar': 'baz'},
+      {'foo': {'bar': "qux"}},
+      {'foo.bar': 'qux'},
+      {'foo:bar': 'qux'},
+      {},
+      0,
+      undefined
+    ], [
+      {'foo': {'bar': "baz"}, 'label': 'simpleRule'},
+      {'foo_bar': 'baz', 'label': 'simpleRule2'}
+    ],
+    'Rule matched and labeled 2 objects',
+    t.ok);
+
+  lf.setDelimiter('_');
+
+  fixture.deepEqual([
+      {'foo': {'bar': "baz"}},
+      {'foo.bar': 'baz'},
+      {'foo_bar': 'baz'},
+      {'foo': {'bar': "qux"}},
+      {'foo.bar': 'qux'},
+      {'foo:bar': 'qux'},
+      {},
+      0,
+      undefined
+    ], [
+      {'foo': {'bar': "baz"}, 'label': 'simpleRule2'},
+      {'foo.bar': 'baz', 'label': 'simpleRule'}
+    ],
+    'Rule matched and labeled 2 objects',
     t.ok,
     100);
 });

--- a/test/index.js
+++ b/test/index.js
@@ -4,11 +4,11 @@ var tst = require('transform-stream-test');
 var LogicFilter = require('../index');
 
 
-test('rule: simple', function(t) {
+test('rule: simple string', function(t) {
   var lf = new LogicFilter(),
       fixture = tst(t, lf);
 
-  lf.add('simpleRule1', {'foo': 'bar'});
+  lf.add('simpleRule1', 'foo === "bar"');
 
   t.plan(1);
 
@@ -29,16 +29,11 @@ test('rule: simple', function(t) {
 });
 
 
-test('rule: and', function(t) {
+test('rule: and string', function(t) {
   var lf = new LogicFilter(),
       fixture = tst(t, lf);
 
-  lf.add('simpleRule1', {
-    and: {
-      'foo': 'bar',
-      'bar': 'qux'
-    }
-  });
+  lf.add('simpleRule1', 'foo === "bar" && bar === "qux"');
 
   t.plan(1);
 
@@ -60,16 +55,11 @@ test('rule: and', function(t) {
 });
 
 
-test('rule: or', function(t) {
+test('rule: or string', function(t) {
   var lf = new LogicFilter(),
       fixture = tst(t, lf);
 
-  lf.add('simpleRule1', {
-    or: {
-      'foo': 'bar',
-      'bar': 'qux'
-    }
-  });
+  lf.add('simpleRule1', 'foo === "bar" || bar === "qux"');
 
   t.plan(1);
 
@@ -92,13 +82,11 @@ test('rule: or', function(t) {
 });
 
 
-test('rule: triple equals any', function(t) {
+test('rule: triple equals any string', function(t) {
   var lf = new LogicFilter(),
       fixture = tst(t, lf);
 
-  lf.add('simpleRule1', {
-    'foo': ['bar', 'baz', 'qux']
-  });
+  lf.add('simpleRule1', '(foo === "bar" || foo === "baz") || foo === "qux"');
 
   t.plan(1);
 
@@ -113,55 +101,18 @@ test('rule: triple equals any', function(t) {
     ], [
       {'foo': 'bar', 'label': 'simpleRule1'},
       {'foo': 'baz', 'label': 'simpleRule1'},
-      {'foo': 'qux', 'label': 'simpleRule1'},
+      {'foo': 'qux', 'label': 'simpleRule1'}
     ],
     'Rule matched and labeled 3 objects',
     t.ok);
 });
 
 
-test('rule: triple equals ors', function(t) {
+test('rule: not string', function(t) {
   var lf = new LogicFilter(),
       fixture = tst(t, lf);
 
-  lf.add('simpleRule1', {
-    or: {
-      foo: 'qux',
-      or: {
-        'foo': ['bar', 'baz']
-      }
-    }
-  });
-
-  t.plan(1);
-
-  fixture.deepEqual([
-      {'foo': 'bar'},
-      {'foo': 'baz'},
-      {'foo': 'qux'},
-      {'foo': 'foo'},
-      {},
-      0,
-      undefined
-    ], [
-      {'foo': 'bar', 'label': 'simpleRule1'},
-      {'foo': 'baz', 'label': 'simpleRule1'},
-      {'foo': 'qux', 'label': 'simpleRule1'},
-    ],
-    'Rule matched and labeled 3 objects',
-    t.ok);
-});
-
-
-test('rule: not', function(t) {
-  var lf = new LogicFilter(),
-      fixture = tst(t, lf);
-
-  lf.add('simpleRule1', {
-    not: {
-      'foo': 'bar'
-    }
-  });
+  lf.add('simpleRule1', 'foo !== "bar"');
 
   t.plan(1);
 
@@ -183,16 +134,11 @@ test('rule: not', function(t) {
 });
 
 
-test('rule: not -> implied and', function(t) {
+test('rule: not -> and string', function(t) {
   var lf = new LogicFilter(),
       fixture = tst(t, lf);
 
-  lf.add('simpleRule1', {
-    not: {
-      'foo': 'bar',
-      'bar': 'qux'
-    }
-  });
+  lf.add('simpleRule1', '!(foo === "bar" && bar === "qux")');
 
   //!(foo == bar && bar == qux)
 
@@ -219,56 +165,11 @@ test('rule: not -> implied and', function(t) {
 });
 
 
-test('rule: not -> and', function(t) {
+test('rule: not -> or string', function(t) {
   var lf = new LogicFilter(),
       fixture = tst(t, lf);
 
-  lf.add('simpleRule1', {
-    not: {
-      and: {
-        'foo': 'bar',
-        'bar': 'qux'
-      }
-    }
-  });
-
-  //!(foo == bar && bar == qux)
-
-  t.plan(1);
-
-  fixture.deepEqual([
-      {'foo': 'bar', 'bar': 'qux'},
-      {'foo': 'baz', 'bar': 'qux'},
-      {'foo': 'bar', 'bar': 'foo'},
-      {'foo': 'bar'},
-      {'bar': 'qux'},
-      {},
-      0,
-      undefined
-    ], [
-      {'foo': 'baz', 'bar': 'qux', 'label': 'simpleRule1'},
-      {'foo': 'bar', 'bar': 'foo', 'label': 'simpleRule1'},
-      {'foo': 'bar', 'label': 'simpleRule1'},
-      {'bar': 'qux', 'label': 'simpleRule1'},
-      {'label': 'simpleRule1'}
-    ],
-    'Rule matched and labeled 5 objects',
-    t.ok);
-});
-
-
-test('rule: not -> or', function(t) {
-  var lf = new LogicFilter(),
-      fixture = tst(t, lf);
-
-  lf.add('simpleRule', {
-    not: {
-      or: {
-        'foo': 'bar',
-        'bar': 'qux'
-      }
-    }
-  });
+  lf.add('simpleRule', '!(foo === "bar" || bar === "qux")');
 
   //!(foo == bar || bar == qux)
 
@@ -293,19 +194,11 @@ test('rule: not -> or', function(t) {
 });
 
 
-test('rule: and -> or', function(t) {
+test('rule: and -> or string', function(t) {
   var lf = new LogicFilter(),
       fixture = tst(t, lf);
 
-  lf.add('simpleRule', {
-    and: {
-      or: {
-        'foo': 'bar',
-        'bar': 'qux'
-      },
-      'qux': 'baz'
-    }
-  });
+  lf.add('simpleRule', '(foo == "bar" || bar == "qux") && qux === "baz"');
 
   t.plan(1);
 
@@ -330,19 +223,11 @@ test('rule: and -> or', function(t) {
 });
 
 
-test('rule: or -> and', function(t) {
+test('rule: or -> and string', function(t) {
   var lf = new LogicFilter(),
       fixture = tst(t, lf);
 
-  lf.add('simpleRule', {
-    or: {
-      and: {
-        'foo': 'bar',
-        'bar': 'qux'
-      },
-      'qux': 'baz'
-    }
-  });
+  lf.add('simpleRule', '(foo == "bar" && bar == "qux") || qux == "baz"');
 
   t.plan(1);
 
@@ -374,21 +259,11 @@ test('rule: or -> and', function(t) {
 });
 
 
-test('rule: or -> (and not)', function(t) {
+test('rule: or -> (and not) string', function(t) {
   var lf = new LogicFilter(),
       fixture = tst(t, lf);
 
-  lf.add('simpleRule', {
-    or: {
-      and: {
-        'foo': 'bar',
-        'bar': 'qux'
-      },
-      not: {
-        'qux': 'baz'
-      }
-    }
-  });
+  lf.add('simpleRule', '(foo =="bar" && bar == "qux") || !(qux == "baz")');
 
   t.plan(1);
 
@@ -420,21 +295,11 @@ test('rule: or -> (and not)', function(t) {
 });
 
 
-test('rule: and -> (or not)', function(t) {
+test('rule: and -> (or not) string', function(t) {
   var lf = new LogicFilter(),
       fixture = tst(t, lf);
 
-  lf.add('simpleRule', {
-    and: {
-      or: {
-        'foo': 'bar',
-        'bar': 'qux'
-      },
-      not: {
-        'qux': 'baz'
-      }
-    }
-  });
+  lf.add('simpleRule', '(foo=="bar" || bar == "qux") && !(qux=="baz")');
 
   t.plan(1);
 
@@ -469,13 +334,11 @@ test('rule: and -> (or not)', function(t) {
 });
 
 
-test('rule: any', function(t) {
+test('rule: any string', function(t) {
   var lf = new LogicFilter(),
       fixture = tst(t, lf);
 
-  lf.add('simpleRule', {
-    'foo': [1, 2, 3]
-  });
+  lf.add('simpleRule', '(foo==1 || foo==2) || foo==3');
 
   t.plan(1);
 
@@ -499,13 +362,11 @@ test('rule: any', function(t) {
 });
 
 
-test('rule: any with array', function(t) {
+test('rule: literal array string', function(t) {
   var lf = new LogicFilter(),
       fixture = tst(t, lf);
 
-  lf.add('simpleRule', {
-    'foo': [[1, 2, 3]]
-  });
+  lf.add('simpleRule', 'foo===[1,2,3]');
 
   t.plan(1);
 
@@ -520,23 +381,18 @@ test('rule: any with array', function(t) {
       0,
       undefined
     ], [
-      {'foo': [1, 2, 3], 'label': 'simpleRule'},
+      {'foo': [1, 2, 3], 'label': 'simpleRule'}
     ],
     'Rule matched and labeled 1 objects',
     t.ok);
 });
 
 
-test('rule: or -> any', function(t) {
+test('rule: or -> any string', function(t) {
   var lf = new LogicFilter(),
       fixture = tst(t, lf);
 
-  lf.add('simpleRule', {
-    or: {
-      'foo': [1, 2, 3],
-      bar: 'qux'
-    }
-  });
+  lf.add('simpleRule', '(foo==1||foo==2)||(foo==3||bar=="qux")');
 
   t.plan(1);
 
@@ -570,11 +426,7 @@ test('rule: not -> any', function(t) {
   var lf = new LogicFilter(),
       fixture = tst(t, lf);
 
-  lf.add('simpleRule', {
-    not: {
-      'foo': [1, 2, 3]
-    }
-  });
+  lf.add('simpleRule', '!((foo==1||foo==2)||foo==3)');
 
   t.plan(1);
 
@@ -602,43 +454,11 @@ test('rule: not -> any', function(t) {
 });
 
 
-test('rule: literal array equality', function(t) {
-  var lf = new LogicFilter(),
-      fixture = tst(t, lf);
-
-  lf.add('simpleRule', {
-    'foo': {
-      value: [1, 2, 3]
-    }
-  });
-
-  t.plan(1);
-
-  fixture.deepEqual([
-      {'foo': [1, 2, 3]},
-      {'foo': 1},
-      {'foo': 2},
-      {'foo': 3},
-      {'foo': 4},
-      {'bar': [1, 2, 3]},
-      {},
-      0,
-      undefined
-    ], [
-      {'foo': [1, 2, 3], 'label': 'simpleRule'}
-    ],
-    'Rule matched and labeled 1 object',
-    t.ok);
-});
-
-
 test('rule: simple array in array', function(t) {
   var lf = new LogicFilter(),
       fixture = tst(t, lf);
 
-  lf.add('simpleRule', {
-    'foo': [[1, 2, 3]]
-  });
+  lf.add('simpleRule', 'foo==[1,2,3]');
 
   t.plan(1);
 
@@ -660,13 +480,11 @@ test('rule: simple array in array', function(t) {
 });
 
 
-test('rule: array/values in array', function(t) {
+test('rule: array/values in array string', function(t) {
   var lf = new LogicFilter(),
       fixture = tst(t, lf);
 
-  lf.add('simpleRule', {
-    'foo': [[1, 2, 3], 1, 2, 3]
-  });
+  lf.add('simpleRule', '(foo==[1,2,3]||foo==1) || (foo==2||foo==3)');
 
   t.plan(1);
 
@@ -691,17 +509,11 @@ test('rule: array/values in array', function(t) {
 });
 
 
-test('rule: literal object equality', function(t) {
+test('rule: literal object equality string', function(t) {
   var lf = new LogicFilter(),
       fixture = tst(t, lf);
 
-  lf.add('simpleRule', {
-    'foo': {
-      value: {
-        'bar': 'baz'
-      }
-    }
-  });
+  lf.add('simpleRule', 'foo=={bar:"baz"}');
 
   t.plan(1);
 
@@ -723,17 +535,11 @@ test('rule: literal object equality', function(t) {
 });
 
 
-test('rule: literal array inequality', function(t) {
+test('rule: literal array inequality string', function(t) {
   var lf = new LogicFilter(),
       fixture = tst(t, lf);
 
-  lf.add('simpleRule', {
-    not: {
-      'foo': {
-        value: [1, 2, 3]
-      }
-    }
-  });
+  lf.add('simpleRule', 'foo!=[1,2,3]');
 
   t.plan(1);
 
@@ -760,19 +566,11 @@ test('rule: literal array inequality', function(t) {
 });
 
 
-test('rule: literal object inequality', function(t) {
+test('rule: literal object inequality string', function(t) {
   var lf = new LogicFilter(),
       fixture = tst(t, lf);
 
-  lf.add('simpleRule', {
-    not: {
-      'foo': {
-        value: {
-          'bar': 'baz'
-        }
-      }
-    }
-  });
+  lf.add('simpleRule', 'foo!={bar:"baz"}');
 
   t.plan(1);
 
@@ -799,11 +597,11 @@ test('rule: literal object inequality', function(t) {
 });
 
 
-test('rule: simple update', function(t) {
+test('rule: simple update string', function(t) {
   var lf = new LogicFilter(),
       fixture = tst(t, lf);
 
-  lf.add('simpleRule', {'foo': 'bar'});
+  lf.add('simpleRule', 'foo==="bar"');
 
   t.plan(2);
 
@@ -823,7 +621,7 @@ test('rule: simple update', function(t) {
     'Rule matched and labeled 2 objects',
     t.ok);
 
-  lf.update('simpleRule', {'foo': 'baz'});
+  lf.update('simpleRule', 'foo=="baz"');
 
   fixture.deepEqual([
       {'foo': 'bar'},
@@ -842,11 +640,257 @@ test('rule: simple update', function(t) {
 });
 
 
+test('rule: nested object and string', function(t) {
+  var lf = new LogicFilter(),
+      fixture = tst(t, lf);
+
+  lf.add('simpleRule', 'foo.bar=="baz"&&foo.qux=="bar"');
+
+  t.plan(1);
+
+  fixture.deepEqual([
+      {'foo': {'bar': 'baz', 'qux': 'bar'}},
+      {'foo': {'qux': 'bar'}},
+      {'foo': {'bar': 'baz', 'baz': 'qux'}},
+      {'foo': {'bar': 'baz'}},
+      {'bar': 'baz', 'qux': 'bar'},
+      {'foo': 'baz'},
+      {'foo': 'bar'},
+      {'bar': {'bar': 'baz'}},
+      {},
+      0,
+      undefined
+    ], [
+      {'foo': {'bar': 'baz', 'qux': 'bar'}, 'label': 'simpleRule'}
+    ],
+    'Rule matched and labeled 1 object',
+    t.ok);
+});
+
+
+test('rule: nested object or string', function(t) {
+  var lf = new LogicFilter(),
+      fixture = tst(t, lf);
+
+  lf.add('simpleRule', 'foo.bar=="baz"||foo.qux=="bar"');
+
+  t.plan(1);
+
+  fixture.deepEqual([
+      {'foo': {'bar': 'baz', 'qux': 'bar'}},
+      {'foo': {'qux': 'bar'}},
+      {'foo': {'bar': 'baz', 'baz': 'qux'}},
+      {'foo': {'bar': 'baz'}},
+      {'bar': 'baz', 'qux': 'bar'},
+      {'foo': 'baz'},
+      {'foo': 'bar'},
+      {'bar': {'bar': 'baz'}},
+      {},
+      0,
+      undefined
+    ], [
+      {'foo': {'bar': 'baz', 'qux': 'bar'}, 'label': 'simpleRule'},
+      {'foo': {'qux': 'bar'}, 'label': 'simpleRule'},
+      {'foo': {'bar': 'baz', 'baz': 'qux'}, 'label': 'simpleRule'},
+      {'foo': {'bar': 'baz'}, 'label': 'simpleRule'}
+    ],
+    'Rule matched and labeled 4 objects',
+    t.ok);
+});
+
+
+test('rule: nested object not -> implied and string', function(t) {
+  var lf = new LogicFilter(),
+      fixture = tst(t, lf);
+
+  lf.add('simpleRule', 'foo.bar!="baz"&&foo.qux!="bar"');
+
+  t.plan(1);
+
+  fixture.deepEqual([
+      {'foo': {'bar': 'baz', 'qux': 'bar'}},
+      {'foo': {'qux': 'bar'}},
+      {'foo': {'bar': 'baz', 'baz': 'qux'}},
+      {'foo': {'bar': 'baz'}},
+      {'bar': 'baz', 'qux': 'bar'},
+      {'foo': 'baz'},
+      {'foo': 'bar'},
+      {'bar': {'bar': 'baz'}},
+      {},
+      0,
+      undefined
+    ], [
+      {'bar': 'baz', 'qux': 'bar', 'label': 'simpleRule'},
+      {'foo': 'baz', 'label': 'simpleRule'},
+      {'foo': 'bar', 'label': 'simpleRule'},
+      {'bar': {'bar': 'baz'}, 'label': 'simpleRule'},
+      {'label': 'simpleRule'}
+    ],
+    'Rule matched and labeled 8 objects',
+    t.ok);
+});
+
+
+test('rule: nested object not -> and string', function(t) {
+  var lf = new LogicFilter(),
+      fixture = tst(t, lf);
+
+  lf.add('simpleRule', '!(foo.bar=="baz"&&foo.qux=="bar")');
+
+  t.plan(1);
+
+  fixture.deepEqual([
+      {'foo': {'bar': 'baz', 'qux': 'bar'}},
+      {'foo': {'qux': 'bar'}},
+      {'foo': {'bar': 'baz', 'baz': 'qux'}},
+      {'foo': {'bar': 'baz'}},
+      {'bar': 'baz', 'qux': 'bar'},
+      {'foo': 'baz'},
+      {'foo': 'bar'},
+      {'bar': {'bar': 'baz'}},
+      {},
+      0,
+      undefined
+    ], [
+      {'foo': {'qux': 'bar'}, 'label': 'simpleRule'},
+      {'foo': {'bar': 'baz', 'baz': 'qux'}, 'label': 'simpleRule'},
+      {'foo': {'bar': 'baz'}, 'label': 'simpleRule'},
+      {'bar': 'baz', 'qux': 'bar', 'label': 'simpleRule'},
+      {'foo': 'baz', 'label': 'simpleRule'},
+      {'foo': 'bar', 'label': 'simpleRule'},
+      {'bar': {'bar': 'baz'}, 'label': 'simpleRule'},
+      {'label': 'simpleRule'}
+    ],
+    'Rule matched and labeled 8 objects',
+    t.ok);
+});
+
+
+test('rule: nested object not -> or string', function(t) {
+  var lf = new LogicFilter(),
+      fixture = tst(t, lf);
+
+  lf.add('simpleRule', '!(foo.bar=="baz"||foo.qux=="bar")');
+
+  t.plan(1);
+
+  fixture.deepEqual([
+      {'foo': {'bar': 'baz', 'qux': 'bar'}},
+      {'foo': {'qux': 'bar'}},
+      {'foo': {'bar': 'baz', 'baz': 'qux'}},
+      {'foo': {'bar': 'baz'}},
+      {'foo': {}},
+      {'bar': 'baz', 'qux': 'bar'},
+      {'foo': 'baz'},
+      {'foo': 'bar'},
+      {'bar': {'bar': 'baz'}},
+      {},
+      0,
+      undefined
+    ], [
+      {'foo': {}, 'label': 'simpleRule'},
+      {'bar': 'baz', 'qux': 'bar', 'label': 'simpleRule'},
+      {'foo': 'baz', 'label': 'simpleRule'},
+      {'foo': 'bar', 'label': 'simpleRule'},
+      {'bar': {'bar': 'baz'}, 'label': 'simpleRule'},
+      {'label': 'simpleRule'}
+    ],
+    'Rule matched and labeled 6 objects',
+    t.ok);
+});
+
+
+test('rule: exists string', function(t) {
+  var lf = new LogicFilter(),
+      fixture = tst(t, lf);
+
+  lf.add('simpleRule', 'foo');
+
+  t.plan(1);
+
+  fixture.deepEqual([
+      {'foo': 1},
+      {'foo': true},
+      {'foo': false},
+      {'foo': null},
+      {'foo': 'one'},
+      {'foo': {'bar': 'baz'}},
+      {'foo': [1, 2, 3]},
+      {'bar': 'foo'},
+      {},
+      0,
+      undefined
+    ], [
+      {'foo': 1, 'label': 'simpleRule'},
+      {'foo': true, 'label': 'simpleRule'},
+      {'foo': false, 'label': 'simpleRule'},
+      {'foo': null, 'label': 'simpleRule'},
+      {'foo': 'one', 'label': 'simpleRule'},
+      {'foo': {'bar': 'baz'}, 'label': 'simpleRule'},
+      {'foo': [1, 2, 3], 'label': 'simpleRule'}
+    ],
+    'Rule matched and labeled 7 objects',
+    t.ok);
+});
+
+
+test('rule: exists false string', function(t) {
+  var lf = new LogicFilter(),
+      fixture = tst(t, lf);
+
+  lf.add('simpleRule', '!foo');
+
+  t.plan(1);
+
+  fixture.deepEqual([
+      {'foo': 1},
+      {'foo': true},
+      {'foo': false},
+      {'foo': null},
+      {'foo': 'one'},
+      {'foo': {'bar': 'baz'}},
+      {'foo': [1, 2, 3]},
+      {'bar': 'foo'},
+      {},
+      0,
+      undefined
+    ], [
+      {'bar': 'foo', 'label': 'simpleRule'},
+      {'label': 'simpleRule'}
+    ],
+    'Rule matched and labeled 2 objects',
+    t.ok);
+});
+
+test('Unparseable rule', function(t) {
+  var lf = new LogicFilter();
+
+  t.ifError(lf.add('bad rule', 'blah =='), 'Correctly did not parse bad string');
+  t.end();
+});
+
+test('Update nonexistent rule', function(t) {
+  var lf = new LogicFilter();
+
+  t.ifError(lf.update('bad rule', 'blah =='), 'Did not update non-existent rule');
+  t.end();
+});
+
+test('Update to unparseable rule', function(t) {
+  var lf = new LogicFilter();
+
+  lf.add('good rule', 'foo == "bar"');
+
+  t.ifError(lf.update('good rule', 'blah =='), 'Correctly did not update to bad rule');
+  t.end();
+});
+
+
 test('rule: simple remove', function(t) {
   var lf = new LogicFilter(),
       fixture = tst(t, lf);
 
-  lf.add('simpleRule', {'foo': 'bar'});
+  lf.add('simpleRule', 'foo == "bar"');
 
   t.plan(2);
 
@@ -883,463 +927,12 @@ test('rule: simple remove', function(t) {
     100);
 });
 
-
-test('bad _applyOperator', function(t) {
-  var lf = new LogicFilter();
-
-  t.throws(lf._applyOperator.bind(lf, 'bad', [true, false, true]),
-           /Applying non-existent operator/, 'Should throw error');
-  t.end();
-});
-
-
-test('null filter', function(t) {
-  var lf = new LogicFilter(),
-      counter = 0;
-
-  t.ifError(lf._applyFilter('and', null, {'foo': 'bar'}));
-  t.end();
-});
-
-
-test('rule: invalid filter throws', function(t) {
-  var lf = new LogicFilter();
-
-  t.throws(lf._applyFilter.bind(lf, 'and', {and: 'foo'}, {'foo': {'bar': 'baz'}}));
-  t.end();
-});
-
-
-test('rule: nested object and', function(t) {
+//FAIL (fix in next release of logic-filter-string)
+/*test('rule: doubly nested object string', function(t) {
   var lf = new LogicFilter(),
       fixture = tst(t, lf);
 
-  lf.add('simpleRule', {
-    'foo': {
-      and: {
-        'bar': 'baz',
-        'qux': 'bar'
-      }
-    }
-  });
-
-  t.plan(1);
-
-  fixture.deepEqual([
-      {'foo': {'bar': 'baz', 'qux': 'bar'}},
-      {'foo': {'qux': 'bar'}},
-      {'foo': {'bar': 'baz', 'baz': 'qux'}},
-      {'foo': {'bar': 'baz'}},
-      {'bar': 'baz', 'qux': 'bar'},
-      {'foo': 'baz'},
-      {'foo': 'bar'},
-      {'bar': {'bar': 'baz'}},
-      {},
-      0,
-      undefined
-    ], [
-      {'foo': {'bar': 'baz', 'qux': 'bar'}, 'label': 'simpleRule'}
-    ],
-    'Rule matched and labeled 1 object',
-    t.ok);
-});
-
-
-test('rule: nested object implied and', function(t) {
-  var lf = new LogicFilter(),
-      fixture = tst(t, lf);
-
-  lf.add('simpleRule', {
-    'foo': {
-      'bar': 'baz',
-      'qux': 'bar'
-    }
-  });
-
-  t.plan(1);
-
-  fixture.deepEqual([
-      {'foo': {'bar': 'baz', 'qux': 'bar'}},
-      {'foo': {'qux': 'bar'}},
-      {'foo': {'bar': 'baz', 'baz': 'qux'}},
-      {'foo': {'bar': 'baz'}},
-      {'bar': 'baz', 'qux': 'bar'},
-      {'foo': 'baz'},
-      {'foo': 'bar'},
-      {'bar': {'bar': 'baz'}},
-      {},
-      0,
-      undefined
-    ], [
-      {'foo': {'bar': 'baz', 'qux': 'bar'}, 'label': 'simpleRule'}
-    ],
-    'Rule matched and labeled 1 object',
-    t.ok);
-});
-
-
-test('rule: nested object or', function(t) {
-  var lf = new LogicFilter(),
-      fixture = tst(t, lf);
-
-  lf.add('simpleRule', {
-    'foo': {
-      or: {
-        'bar': 'baz',
-        'qux': 'bar'
-      }
-    }
-  });
-
-  t.plan(1);
-
-  fixture.deepEqual([
-      {'foo': {'bar': 'baz', 'qux': 'bar'}},
-      {'foo': {'qux': 'bar'}},
-      {'foo': {'bar': 'baz', 'baz': 'qux'}},
-      {'foo': {'bar': 'baz'}},
-      {'bar': 'baz', 'qux': 'bar'},
-      {'foo': 'baz'},
-      {'foo': 'bar'},
-      {'bar': {'bar': 'baz'}},
-      {},
-      0,
-      undefined
-    ], [
-      {'foo': {'bar': 'baz', 'qux': 'bar'}, 'label': 'simpleRule'},
-      {'foo': {'qux': 'bar'}, 'label': 'simpleRule'},
-      {'foo': {'bar': 'baz', 'baz': 'qux'}, 'label': 'simpleRule'},
-      {'foo': {'bar': 'baz'}, 'label': 'simpleRule'}
-    ],
-    'Rule matched and labeled 4 objects',
-    t.ok);
-});
-
-
-test('rule: nested object not -> implied and', function(t) {
-  var lf = new LogicFilter(),
-      fixture = tst(t, lf);
-
-  lf.add('simpleRule', {
-    'foo': {
-      not: {
-        'bar': 'baz',
-        'qux': 'bar'
-      }
-    }
-  });
-
-  t.plan(1);
-
-  fixture.deepEqual([
-      {'foo': {'bar': 'baz', 'qux': 'bar'}},
-      {'foo': {'qux': 'bar'}},
-      {'foo': {'bar': 'baz', 'baz': 'qux'}},
-      {'foo': {'bar': 'baz'}},
-      {'bar': 'baz', 'qux': 'bar'},
-      {'foo': 'baz'},
-      {'foo': 'bar'},
-      {'bar': {'bar': 'baz'}},
-      {},
-      0,
-      undefined
-    ], [
-      {'foo': {'qux': 'bar'}, 'label': 'simpleRule'},
-      {'foo': {'bar': 'baz', 'baz': 'qux'}, 'label': 'simpleRule'},
-      {'foo': {'bar': 'baz'}, 'label': 'simpleRule'},
-      {'bar': 'baz', 'qux': 'bar', 'label': 'simpleRule'},
-      {'foo': 'baz', 'label': 'simpleRule'},
-      {'foo': 'bar', 'label': 'simpleRule'},
-      {'bar': {'bar': 'baz'}, 'label': 'simpleRule'},
-      {'label': 'simpleRule'}
-    ],
-    'Rule matched and labeled 8 objects',
-    t.ok);
-});
-
-
-test('rule: nested object not -> and', function(t) {
-  var lf = new LogicFilter(),
-      fixture = tst(t, lf);
-
-  lf.add('simpleRule', {
-    'foo': {
-      not: {
-        and: {
-          'bar': 'baz',
-          'qux': 'bar'
-        }
-      }
-    }
-  });
-
-  t.plan(1);
-
-  fixture.deepEqual([
-      {'foo': {'bar': 'baz', 'qux': 'bar'}},
-      {'foo': {'qux': 'bar'}},
-      {'foo': {'bar': 'baz', 'baz': 'qux'}},
-      {'foo': {'bar': 'baz'}},
-      {'bar': 'baz', 'qux': 'bar'},
-      {'foo': 'baz'},
-      {'foo': 'bar'},
-      {'bar': {'bar': 'baz'}},
-      {},
-      0,
-      undefined
-    ], [
-      {'foo': {'qux': 'bar'}, 'label': 'simpleRule'},
-      {'foo': {'bar': 'baz', 'baz': 'qux'}, 'label': 'simpleRule'},
-      {'foo': {'bar': 'baz'}, 'label': 'simpleRule'},
-      {'bar': 'baz', 'qux': 'bar', 'label': 'simpleRule'},
-      {'foo': 'baz', 'label': 'simpleRule'},
-      {'foo': 'bar', 'label': 'simpleRule'},
-      {'bar': {'bar': 'baz'}, 'label': 'simpleRule'},
-      {'label': 'simpleRule'}
-    ],
-    'Rule matched and labeled 8 objects',
-    t.ok);
-});
-
-
-test('rule: nested object or', function(t) {
-  var lf = new LogicFilter(),
-      fixture = tst(t, lf);
-
-  lf.add('simpleRule', {
-    'foo': {
-      or: {
-        'bar': 'baz',
-        'qux': 'bar'
-      }
-    }
-  });
-
-  t.plan(1);
-
-  fixture.deepEqual([
-      {'foo': {'bar': 'baz', 'qux': 'bar'}},
-      {'foo': {'qux': 'bar'}},
-      {'foo': {'bar': 'baz', 'baz': 'qux'}},
-      {'foo': {'bar': 'baz'}},
-      {'bar': 'baz', 'qux': 'bar'},
-      {'foo': 'baz'},
-      {'foo': 'bar'},
-      {'bar': {'bar': 'baz'}},
-      {},
-      0,
-      undefined
-    ], [
-      {'foo': {'bar': 'baz', 'qux': 'bar'}, 'label': 'simpleRule'},
-      {'foo': {'qux': 'bar'}, 'label': 'simpleRule'},
-      {'foo': {'bar': 'baz', 'baz': 'qux'}, 'label': 'simpleRule'},
-      {'foo': {'bar': 'baz'}, 'label': 'simpleRule'}
-    ],
-    'Rule matched and labeled 4 objects',
-    t.ok);
-});
-
-
-test('rule: nested object not -> or', function(t) {
-  var lf = new LogicFilter(),
-      fixture = tst(t, lf);
-
-  lf.add('simpleRule', {
-    'foo': {
-      not: {
-        or: {
-          'bar': 'baz',
-          'qux': 'bar'
-        }
-      }
-    }
-  });
-
-  t.plan(1);
-
-  fixture.deepEqual([
-      {'foo': {'bar': 'baz', 'qux': 'bar'}},
-      {'foo': {'qux': 'bar'}},
-      {'foo': {'bar': 'baz', 'baz': 'qux'}},
-      {'foo': {'bar': 'baz'}},
-      {'foo': {}},
-      {'bar': 'baz', 'qux': 'bar'},
-      {'foo': 'baz'},
-      {'foo': 'bar'},
-      {'bar': {'bar': 'baz'}},
-      {},
-      0,
-      undefined
-    ], [
-      {'foo': {}, 'label': 'simpleRule'},
-      {'bar': 'baz', 'qux': 'bar', 'label': 'simpleRule'},
-      {'foo': 'baz', 'label': 'simpleRule'},
-      {'foo': 'bar', 'label': 'simpleRule'},
-      {'bar': {'bar': 'baz'}, 'label': 'simpleRule'},
-      {'label': 'simpleRule'}
-    ],
-    'Rule matched and labeled 6 objects',
-    t.ok);
-});
-
-
-test('rule: exists', function(t) {
-  var lf = new LogicFilter(),
-      fixture = tst(t, lf);
-
-  lf.add('simpleRule', {
-    'foo': {
-      exists: true
-    }
-  });
-
-  t.plan(1);
-
-  fixture.deepEqual([
-      {'foo': 1},
-      {'foo': true},
-      {'foo': false},
-      {'foo': null},
-      {'foo': 'one'},
-      {'foo': {'bar': 'baz'}},
-      {'foo': [1, 2, 3]},
-      {'bar': 'foo'},
-      {},
-      0,
-      undefined
-    ], [
-      {'foo': 1, 'label': 'simpleRule'},
-      {'foo': true, 'label': 'simpleRule'},
-      {'foo': false, 'label': 'simpleRule'},
-      {'foo': null, 'label': 'simpleRule'},
-      {'foo': 'one', 'label': 'simpleRule'},
-      {'foo': {'bar': 'baz'}, 'label': 'simpleRule'},
-      {'foo': [1, 2, 3], 'label': 'simpleRule'}
-    ],
-    'Rule matched and labeled 7 objects',
-    t.ok);
-});
-
-
-test('rule: not exists false', function(t) {
-  var lf = new LogicFilter(),
-      fixture = tst(t, lf);
-
-  lf.add('simpleRule', {
-    not: {
-      'foo': {
-        exists: false
-      }
-    }
-  });
-
-  t.plan(1);
-
-  fixture.deepEqual([
-      {'foo': 1},
-      {'foo': true},
-      {'foo': false},
-      {'foo': null},
-      {'foo': 'one'},
-      {'foo': {'bar': 'baz'}},
-      {'foo': [1, 2, 3]},
-      {'bar': 'foo'},
-      {},
-      0,
-      undefined
-    ], [
-      {'foo': 1, 'label': 'simpleRule'},
-      {'foo': true, 'label': 'simpleRule'},
-      {'foo': false, 'label': 'simpleRule'},
-      {'foo': null, 'label': 'simpleRule'},
-      {'foo': 'one', 'label': 'simpleRule'},
-      {'foo': {'bar': 'baz'}, 'label': 'simpleRule'},
-      {'foo': [1, 2, 3], 'label': 'simpleRule'}
-    ],
-    'Rule matched and labeled 7 objects',
-    t.ok);
-});
-
-
-test('rule: exists false', function(t) {
-  var lf = new LogicFilter(),
-      fixture = tst(t, lf);
-
-  lf.add('simpleRule', {
-    'foo': {
-      exists: false
-    }
-  });
-
-  t.plan(1);
-
-  fixture.deepEqual([
-      {'foo': 1},
-      {'foo': true},
-      {'foo': false},
-      {'foo': null},
-      {'foo': 'one'},
-      {'foo': {'bar': 'baz'}},
-      {'foo': [1, 2, 3]},
-      {'bar': 'foo'},
-      {},
-      0,
-      undefined
-    ], [
-      {'bar': 'foo', 'label': 'simpleRule'},
-      {'label': 'simpleRule'}
-    ],
-    'Rule matched and labeled 2 objects',
-    t.ok);
-});
-
-
-test('rule: not exists true', function(t) {
-  var lf = new LogicFilter(),
-      fixture = tst(t, lf);
-
-  lf.add('simpleRule', {
-    not: {
-      'foo': {
-        exists: true
-      }
-    }
-  });
-
-  t.plan(1);
-
-  fixture.deepEqual([
-      {'foo': 1},
-      {'foo': true},
-      {'foo': false},
-      {'foo': null},
-      {'foo': 'one'},
-      {'foo': {'bar': 'baz'}},
-      {'foo': [1, 2, 3]},
-      {'bar': 'foo'},
-      {},
-      0,
-      undefined
-    ], [
-      {'bar': 'foo', 'label': 'simpleRule'},
-      {'label': 'simpleRule'}
-    ],
-    'Rule matched and labeled 2 objects',
-    t.ok);
-});
-
-
-test('rule: doubly nested object', function(t) {
-  var lf = new LogicFilter(),
-      fixture = tst(t, lf);
-
-  lf.add('simpleRule', {
-    'metrics': {
-      'duration': {
-        'valueI32': 70
-      }
-    }
-  });
+  lf.add('simpleRule', 'metrics.duration.valueI32 === 70');
 
   t.plan(1);
 
@@ -1361,418 +954,4 @@ test('rule: doubly nested object', function(t) {
     ],
     'Rule matched and labeled 3 objects',
     t.ok);
-});
-
-
-test('compareValue', function(t) {
-  var lf = new LogicFilter(),
-      fixture = tst(t, lf);
-
-  t.ifError(lf._compareValue({}, 'foo', null, {}));
-  t.end();
-});
-
-
-test('rule: multiple simple', function(t) {
-  var lf = new LogicFilter(),
-      fixture = tst(t, lf);
-
-  lf.add('simpleRule1', {'foo': 'bar'});
-  lf.add('simpleRule2', {'bar': 'foo'});
-
-  t.plan(1);
-
-  fixture.deepEqual([
-      {'foo': 'bar'},
-      {'foo': 'baz'},
-      {'foo': 'qux'},
-      {'foo': 'bar'},
-      {'bar': 'foo'},
-      {},
-      0,
-      undefined
-    ], [
-      {'foo': 'bar', 'label': 'simpleRule1'},
-      {'foo': 'bar', 'label': 'simpleRule1'},
-      {'bar': 'foo', 'label': 'simpleRule2'}
-    ],
-    'Rule matched and labeled 3 objects',
-    t.ok);
-});
-
-
-test('rule: multiple same simple', function(t) {
-  var lf = new LogicFilter(),
-      fixture = tst(t, lf);
-
-  lf.add('simpleRule1', {'foo': 'bar'});
-  lf.add('simpleRule2', {'foo': 'bar'});
-
-  t.plan(1);
-
-  fixture.deepEqual([
-      {'foo': 'bar'},
-      {'foo': 'baz'},
-      {'foo': 'qux'},
-      {'foo': 'bar'},
-      {'bar': 'foo'},
-      {},
-      0,
-      undefined
-    ], [
-      {'foo': 'bar', 'label': 'simpleRule1'},
-      {'foo': 'bar', 'label': 'simpleRule1'},
-      {'foo': 'bar', 'label': 'simpleRule2'},
-      {'foo': 'bar', 'label': 'simpleRule2'}
-    ],
-    'Rule matched and labeled 4 objects',
-    t.ok);
-});
-
-
-test('rule: multiple complex', function(t) {
-  var lf = new LogicFilter(),
-      fixture = tst(t, lf);
-
-  lf.add('rule1', {
-    or: {
-      'foo': 'bar',
-      'bar': 'baz'
-    }
-  });
-  lf.add('rule2', {
-    and: {
-      'foo': 'bar',
-      'qux': {
-        value: {
-          'a': 1,
-          'b': 2
-        }
-      }
-    }
-  });
-
-  t.plan(1);
-
-  fixture.deepEqual([
-      {'foo': 'bar'},
-      {'foo': 'bar', 'bar': 'baz'},
-      {'bar': 'baz'},
-      {'foo': 'bar', 'qux': {'a': 1, 'b': 2}},
-      {'foo': 'bar', 'qux': {'a': 1, 'b': 2, 'c': 3}},
-      {'foo': 'bar', 'qux': 1},
-      {'qux': 'bar'},
-      {},
-      0,
-      undefined
-    ], [
-      {'foo': 'bar', 'label': 'rule1'},
-      {'foo': 'bar', 'bar': 'baz', 'label': 'rule1'},
-      {'bar': 'baz', 'label': 'rule1'},
-      {'foo': 'bar', 'qux': {'a': 1, 'b': 2}, 'label': 'rule1'},
-      {'foo': 'bar', 'qux': {'a': 1, 'b': 2}, 'label': 'rule2'},
-      {'foo': 'bar', 'qux': {'a': 1, 'b': 2, 'c': 3}, 'label': 'rule1'},
-      {'foo': 'bar', 'qux': 1, 'label': 'rule1'}
-    ],
-    'Rule matched and labeled 7 objects',
-    t.ok);
-});
-
-
-test('rule: validation', function(t) {
-  var lf = LogicFilter(),
-      goodRules = {
-        simple: {
-          'foo': 'bar'
-        },
-        simpleAnd: {
-          and: {
-            'foo': 'bar',
-            'bar': 'baz'
-          }
-        },
-        simpleImpliedAnd: {
-          'foo': 'bar',
-          'bar': 'baz'
-        },
-        simpleOr: {
-          or: {
-            'foo': 'bar',
-            'bar': 'baz'
-          }
-        },
-        simpleNot: {
-          not: {
-            'foo': 'bar'
-          }
-        },
-        simpleAny: {
-          'foo': [1, 2, 3]
-        },
-        notImpliedAnd: {
-          not: {
-            'foo': 'bar',
-            'bar': 'baz'
-          }
-        },
-        notAnd: {
-          not: {
-            and: {
-              'foo': 'bar',
-              'bar': 'baz'
-            }
-          }
-        },
-        notOr: {
-          not: {
-            or: {
-              'foo': 'bar',
-              'bar': 'baz'
-            }
-          }
-        },
-        simpleValue: {
-          'foo': {
-            value: [1, 2, 3]
-          }
-        },
-        simpleValue2: {
-          'foo': {
-            value: {
-              'foo': 'bar'
-            }
-          }
-        },
-        simpleValue3: {
-          'foo': {
-            value: 'bar'
-          }
-        },
-        simpleExistsTrue: {
-          'foo': {
-            exists: true
-          }
-        },
-        simpleExistsFalse: {
-          'foo': {
-            exists: false
-          }
-        },
-        nestedAndOr: {
-          and: {
-            or: {
-              'foo': 'bar',
-              'bar': 'baz'
-            },
-            'qux': 'foo'
-          }
-        },
-        nestedOrAnd: {
-          or: {
-            and: {
-              'foo': 'bar',
-              'bar': 'baz'
-            },
-            'qux': 'foo'
-          }
-        },
-        nestedNotAnd: {
-          not: {
-            and: {
-              'foo': 'bar',
-              'bar': 'baz'
-            },
-            'qux': 'foo'
-          }
-        },
-        nestedAndNot: {
-          and: {
-            not: {
-              'foo': 'bar',
-              'bar': 'baz'
-            },
-            'qux': 'foo'
-          }
-        },
-        nestedNotOr: {
-          not: {
-            or: {
-              'foo': 'bar',
-              'bar': 'baz'
-            },
-            'qux': 'foo'
-          }
-        },
-        nestedOrNot: {
-          or: {
-            not: {
-              'foo': 'bar',
-              'bar': 'baz'
-            },
-            'qux': 'foo'
-          }
-        },
-        nestedAndExists: {
-          and: {
-            'foo': {
-              exists: true
-            },
-            'qux': 'foo'
-          }
-        },
-        nestedOrExists: {
-          or: {
-            'foo': {
-              exists: true
-            },
-            'qux': 'foo'
-          }
-        },
-        nestedNotExists: {
-          not: {
-            'foo': {
-              exists: true
-            },
-            'qux': 'foo'
-          }
-        },
-        nestedAndValue: {
-          and: {
-            'foo': {
-              value: {
-                'bar': 'baz'
-              }
-            },
-            'qux': 'foo'
-          }
-        },
-        nestedOrValue: {
-          or: {
-            'foo': {
-              value: {
-                'bar': 'baz'
-              }
-            },
-            'qux': 'foo'
-          }
-        },
-        nestedNotValue: {
-          not: {
-            'foo': {
-              value: {
-                'bar': 'baz'
-              }
-            },
-            'qux': 'foo'
-          }
-        },
-        nestedAndAny: {
-          and: {
-            'foo': [1, 2, 3],
-            'qux': 'foo'
-          }
-        },
-        nestedOrAny: {
-          or: {
-            'foo': [1, 2, 3],
-            'qux': 'foo'
-          }
-        },
-        nestedNotAny: {
-          not: {
-            'foo': [1, 2, 3],
-            'qux': 'foo'
-          }
-        }
-      },
-      badRules = {
-        emptyRule: {},
-        nullRule: null,
-        undefinedRule: undefined,
-        badExists: {
-          'foo': {
-            exists: null
-          }
-        },
-        badExists2: {
-          'foo': {
-            exists: undefined
-          }
-        },
-        badExists3: {
-          'foo': {
-            exists: 0
-          }
-        },
-        badExists4: {
-          'foo': {
-            exists: 1
-          }
-        },
-        badExists5: {
-          'foo': {
-            exists: 'bar'
-          }
-        },
-        badAnd: {
-          and: 'foo'
-        },
-        badOr: {
-          or: 'foo'
-        },
-        badNot: {
-          not: 'foo'
-        },
-        badAndNot: {
-          and: {
-            not: 'foo'
-          }
-        },
-        badAndOr: {
-          and: {
-            or: 'foo'
-          }
-        },
-        badOrAnd: {
-          or: {
-            and: 'foo'
-          }
-        },
-        badOrNot: {
-          or: {
-            not: 'foo'
-          }
-        },
-        badNotAnd: {
-          not: {
-            and: 'foo'
-          }
-        },
-        badNotOr: {
-          not: {
-            or: 'foo'
-          }
-        }
-      };
-
-
-  Object.keys(goodRules).forEach(function(rule) {
-    t.ok(LogicFilter.validate(goodRules[rule]), 'Rule: ' + rule + ' should pass validation');
-  });
-
-  Object.keys(badRules).forEach(function(rule) {
-    t.ifError(LogicFilter.validate(badRules[rule]), 'Rule: ' + rule + ' should fail validation');
-  });
-
-  t.end();
-});
-
-test('rule: add/update invalid rules', function(t) {
-  var lf = new LogicFilter();
-
-  t.ifError(lf.add('invalidRule', {}), 'Empty rule should not be added');
-  lf.add('simpleRule', {'foo': 'bar'});
-  t.ifError(lf.update('simpleRule', {}), 'Rule cannot be updated to empty rule');
-  t.ifError(lf.update('newRule', {'foo': 'bar'}), 'Nonexistent rule cannot be updated');
-  t.end();
-});
+});*/


### PR DESCRIPTION
_What_
Completely redoes the logic filter to use only parsed logic strings (as defined in https://github.com/phoebesimon/node-logic-filter-strings). This branch depends on https://github.com/phoebesimon/node-logic-filter-strings/pull/1 being merged/publish/installed.

_How_
index.js: Reworked the logic to assume that rules are added as strings and to operate on the value returned from parsing the string (an AST).
test/index.js: Got rid of object filter versions of tests

_Why_
The object filters would not let us specify a number of cases, most of which revolve around nested object, which it is essential to handle going forward.
